### PR TITLE
added INIT INFO, fixed agent id name

### DIFF
--- a/templates/init-script.erb
+++ b/templates/init-script.erb
@@ -1,9 +1,20 @@
 #!/bin/bash
-# bamboo-agent<%= @agent_id.to_s.ljust(4) %> Init script for running bamboo agent
+# bamboo-agent<%= @id.to_s.ljust(4) %> Init script for running bamboo agent
 #
 # chkconfig:       2345 98 02
 #
-# description:     Starts and stops bamboo agent <%= @agent_id %>
+# description:     Starts and stops bamboo agent <%= @id %>
+### BEGIN INIT INFO
+# Provides:          bamboo-agent<%= @id %>
+# Required-Start:    $local_fs $remote_fs $network
+# Required-Stop:     $local_fs $remote_fs $network
+# Should-Start:      $named
+# Should-Stop:       $named
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Start Bamboo Agent <%= @id %>.
+# Description:       Start the Bamboo Agent <%= @id %>.
+### END INIT INFO
 
 # This is just a delegator to the Bamboo agent script.
 


### PR DESCRIPTION
Init script failed with the following messages:

```
Mar 13 16:45:25 servername puppet-agent[19050]: Executing '/usr/sbin/update-rc.d bamboo-agent1 defaults'
Mar 13 16:45:25 servername puppet-agent[19050]: Execution of '/usr/sbin/update-rc.d bamboo-agent1 defaults' returned 1: update-rc.d: using dependency based boot sequencing
Mar 13 16:45:25 servername puppet-agent[19050]: insserv: warning: script 'bamboo-agent1' missing LSB tags and overrides
Mar 13 16:45:25 servername puppet-agent[19050]: insserv: There is a loop between service munin-node and bamboo-agent1 if stopped
Mar 13 16:45:25 servername puppet-agent[19050]: insserv:  loop involving service bamboo-agent1 at depth 2
Mar 13 16:45:25 servername puppet-agent[19050]: insserv:  loop involving service munin-node at depth 1
Mar 13 16:45:25 servername puppet-agent[19050]: insserv: Stopping bamboo-agent1 depends on munin-node and therefore on system facility `$all' which can not be true!
Mar 13 16:45:25 servername puppet-agent[19050]: insserv: exiting now without changing boot order!
Mar 13 16:45:25 servername puppet-agent[19050]: update-rc.d: error: insserv rejected the script header
```

And `agent_id` is actually named `id`.
